### PR TITLE
Notify git about push conflict via remote-helper error code

### DIFF
--- a/gitifyhg.py
+++ b/gitifyhg.py
@@ -605,8 +605,8 @@ class GitExporter(object):
         tip = self.repo[tip].rev()
         log("%r %r" % (git_marked_tip, tip))
         if git_marked_tip < tip:
-            die("Remote Mercurial repository contains new commits."
-                " Consider pulling first.")
+            output("error %s already exists\n" % ref)
+            sys.exit(1)
 
         commit_mark = self.parser.read_mark()
         author = self.parser.read_author()


### PR DESCRIPTION
Besides "already exists", you can also use "non-fast forward". See also function push_update_ref_status() in transport-helper.c in the git sources
