### PR TITLE
Change error code "already exists" to "non-fast forward"

### DIFF
--- a/gitifyhg.py
+++ b/gitifyhg.py
@@ -605,7 +605,7 @@ class GitExporter(object):
         tip = self.repo[tip].rev()
         log("%r %r" % (git_marked_tip, tip))
         if git_marked_tip < tip:
-            output("error %s already exists\n" % ref)
+            output("error %s non-fast forward\n" % ref)
             sys.exit(1)
 
         commit_mark = self.parser.read_mark()


### PR DESCRIPTION
The "already exists" error code relies on a change in git.git "next",
which is (as far as I can tell) in no released version of git.
On the other hand, the "non-fast forward" code has been supported
since git v1.7.10
