### PR TITLE
Only check whether DEBUG_GITIFYHG is set

### DIFF
--- a/gitifyhg.py
+++ b/gitifyhg.py
@@ -35,7 +35,7 @@ from mercurial import hg
 from mercurial.error import RepoLookupError
 
 
-DEBUG_GITIFYHG = os.environ.get("DEBUG_GITIFYHG", "").lower() == "on"
+DEBUG_GITIFYHG = os.environ.get("DEBUG_GITIFYHG") != None
 
 
 def log(msg, level="DEBUG"):


### PR DESCRIPTION
git has multiple debug env variables, but for all of them,
it only matters if they are set or not -- the exact value
is irrelevant. To avoid surprise, gitifyhg should do the same.
