### PR TITLE
Add some simple notes support

### DIFF
--- a/gitifyhg.py
+++ b/gitifyhg.py
@@ -490,8 +490,6 @@ class HGImporter(object):
 
         # output a git note indicating the mercurial hash of the added commits
         output("commit refs/notes/hg")
-        # TODO: obtain SHA-1 of last commit to refs/notes/hg and use it:
-        #output("from :%s" % (TODO-PARENT-SHA1))
         # TODO: Should we insert a fake committer like "gitifyhg" here?
         #output("committer %s" % (committer))
         output("committer gitifyhg <unknown> 1359154199 +0100")
@@ -499,6 +497,12 @@ class HGImporter(object):
         data = "This note update brought to you by gitifyhg"
         output("data %d" % len(data))
         output(data)
+        # HACK: obtain SHA-1 of last commit to refs/notes/hg and use it
+        try:
+            PARENT_SHA1 = subprocess.check_output(['git', 'show-ref', 'refs/notes/hg', '-s'])
+            output("from %s" % (PARENT_SHA1.rstrip()))
+        except subprocess.CalledProcessError:
+            pass
         for rev in revs:
             output("N inline :%d" % (self.marks.revision_to_mark(rev)))
             data = self.repo[rev].hex()


### PR DESCRIPTION
This is a very early proof-of-concept work of adding notes support, see the discussion on issue #4. This should NOT be merged, as there are multiple issues with it. Partly because things are not implemented yet, partly because I do not yet fully understand how git notes work. Here are some things that need to be done.
1. It only adds notes when importing new commits; if you add commits in git, then `git push` no note is added to the git commit, not even when you `git pull` again.
2. Actually, it won't work after the initial import either; if there are new commits made on the hg side then this happens:

```
$ git pull
warning: Not updating refs/notes/hg (new tip SOME_SHA does not contain OTHER_SHA)
fatal: Error while running fast-import
$
```

This is because notes are managed in commits, and the commits my hack generates do not bother to specify the correct parent commit. They really should. (I am somewhat surprised that cloning a repo with more than one commit works with this hack... clearly there is more I am not understanding).
1. What should be used as the committer and commit message for these not commits? I guess the committer could be something like "gitifyhg <unknown>", the message could be empty or contain information about the import (e.g. when it happened, which revisions where imported, the weather forecast...)
2. If I understand correctly how notes work, then we can have multiple notemodify messages in a single notes commit there. So instead of adding each note in its own "commit", we should just add all notes at once in a single commit to refs/notes/hg. 

I am sure there are more problems. But at least now we (well, at least I, not sure how helpful my rambling are :-) have a slightly better idea of what needs to be done.
