### PR TITLE
Add .travis.yml configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+
+# install recent git version, and make sure the git config
+# contains suitable default
+before_install:
+  - sudo apt-get update -qq
+  - sudo add-apt-repository -y ppa:pdoes/ppa
+  - sudo apt-get install -qq git
+  - git config --global user.email you@example.com
+  - git config --global user.name Gitifyhg
+  - git config --global push.default simple
+
+# install dependencies and gitifyhg itself;
+# py.test is already preinstalled
+install:
+  - "pip install -q --use-mirrors sh"
+  - "pip install -q --use-mirrors path.py>=2.5"
+  - "pip install -q --use-mirrors Mercurial==$HG_VERSION"
+  - "python setup.py -q install"
+
+# specify various mercurial versions to test against
+# TODO: Also test against multiple git versions;
+# this may require setting up a custom PPA with suitable
+# .deb's in it.
+env:
+  - HG_VERSION=2.4.2  # latest release
+#  - HG_VERSION=2.4.1
+#  - HG_VERSION=2.3.2
+  - HG_VERSION=2.2.2  # Debian Wheezy, Ubuntu 12.10
+  - HG_VERSION=2.0.2  # Ubuntu 12.04 LTS
+  - HG_VERSION=1.9.1  # Ubuntu 11.10
+#  - HG_VERSION=2.2.3
+#  - HG_VERSION=2.1.2
+#  - HG_VERSION=2.0.2
+#  - HG_VERSION=1.9.3
+#  - HG_VERSION=1.8.4
+#  - HG_VERSION=1.6.4  # Debian Squeeze
+
+# command to run actual tests
+# We also output the git and hg versions to make sure we are using
+# the right ones.
+# Also, switch the traceback format to 'short' to work around
+# a bug in py.test <= 2.3.4.
+script:
+  - git --version
+  - hg --version
+  - py.test --tb=short


### PR DESCRIPTION
This adds a configuration file for Travis CI, as discussed on #20. To make sure the tests actually pass, first pull request #27 should be merged.

For an example output, see
  https://travis-ci.org/fingolfin/gitifyhg/builds/4452561

Note that travis normally ships git 1.7.9.5. I vaguely recall that Felipe made some fast-export fixes at the time he submitted his remote-hg for git.git/contrib, which were meant to address issues that affect remote helpers. So it might be a good idea to require git 1.8.0 (which introduced them).

But in any case, the travis setup should likely also test against multiple git versions. For this, setting up a PPA with all desired git versions in it might be the best way to go.
