### PR TITLE
Remote names

### DIFF
--- a/gitifyhg.py
+++ b/gitifyhg.py
@@ -458,7 +458,7 @@ class HGImporter(object):
                           self.marks.revisions_to_marks.iteritems() if mark > last_notes_mark]
         if not mark_to_hgsha1:
             return
-        output("commit refs/notes/hg-%s" % (self.hgremote.alias))
+        output("commit refs/notes/hg-%s" % (self.hgremote.uuid))
         output("mark :%d" % (self.marks.new_notes_mark()))
         output("committer <gitifyhg-note> %s" % (strftime('%s %z')))
         message = u"hg from %s (%s)\n" % (self.prefix, self.hgremote.url)


### PR DESCRIPTION
This addresses issue #14 by storing the local hg clone under `.git/hg/<SHA1-of-remote-URL>/clone` instead of  `.git/hg/REMOTENAME/clone`. The second commit likewise adjust the notes code.

After some testing, it seems that no transition code is required (at least for everything besides notes), because gitifyhg will just behave as if this was a fresh clone, and recreate the local clone.

The notes are a different story of course. But since they are still incomplete and have been in only for a few minutes, I figured this was nothing to worry about.
