### PR TITLE
Notes in empty fetch (issue #30)

### DIFF
--- a/test/test_push.py
+++ b/test/test_push.py
@@ -61,7 +61,6 @@ def test_simple_push_updates_notes(hg_repo, git_dir):
     assert_git_notes(hgsha1s)
 
 
-@pytest.mark.xfail
 def test_simple_push_updates_notes_after_contentful_pull(hg_repo, git_dir):
     """Issue #30: check that notes are eventually applied"""
     git_repo = clone_repo(git_dir, hg_repo)


### PR DESCRIPTION
Despite issuing an error message, the notes ref is still updated and is valid, and the return code is 0. Regardless, the stderr noise reported in issue #30 is ugly. This patch series (a) adds tests and (b) defers updating the notes ref until a fetch that has non-notes content.
