### PR TITLE
Set HGPLAIN env variable at start of gitifyhg, closes #26

### DIFF
--- a/gitifyhg.py
+++ b/gitifyhg.py
@@ -27,6 +27,12 @@ import subprocess
 from path import path as p
 from time import strftime
 
+
+# Enable "plain" mode to make us resilient against changes to the locale, as we
+# rely on parsing certain messages produced by Mercurial. See issue #26.
+os.environ['HGPLAIN'] = '1'
+
+
 from mercurial.ui import ui
 from mercurial.context import memctx, memfilectx
 from mercurial.error import Abort

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,7 +21,6 @@ def hg_repo(tmpdir):
         an initialized hg repository with a single commit'''
     os.environ['DEBUG_GITIFYHG'] = "on"
     os.environ['GIT_PAGER'] = 'cat'
-    os.environ['HGPLAIN'] = '1'
     tmpdir = p(tmpdir.strpath).abspath()
     hg_base = tmpdir.joinpath('hg_base')  # an hg repo to clone from
     hg_base.mkdir()

--- a/test/test_push.py
+++ b/test/test_push.py
@@ -124,9 +124,7 @@ def test_push_conflict_default_double(git_dir, hg_repo):
     assert sh.git.push(_ok_code=1).stderr.find("master -> master (non-fast-forward)") > 0
 
 
-@pytest.mark.xfail
 def test_push_conflict_default_double_non_english(git_dir, hg_repo):
-    del os.environ['HGPLAIN']
     os.environ['LANG'] = 'de_DE'
     git_repo = clone_repo(git_dir, hg_repo)
     sh.cd(hg_repo)


### PR DESCRIPTION
The first commit adds a new xfail test to demonstrate issue #26 explicitly.

The second commit adds a fix for the issue by setting the HGPLAIN env var at the start of gitifyhg. At the same time, it changes the test harness to _not_ set it as part of the test fixture, as this was covering up potential test failures. And it should be obsolete now, too, due to us setting it in gitifyhg directly.
