### PR TITLE
Mercurial author parsing fixes

### DIFF
--- a/gitifyhg/hgimporter.py
+++ b/gitifyhg/hgimporter.py
@@ -32,9 +32,10 @@ AUTHOR = re.compile(r'^([^<>]+)?(<(?:[^<>]*)>| [^ ]*@.*|[<>].*)$')
 
 def sanitize_author(author):
     '''Mercurial allows a more freeform user string than git, so we have to
-    massage it to be compatible. Git expects "name <email>".'''
+    massage it to be compatible. Git expects "name <email>", where email can be
+    empty (as long as it's surrounded by <>).'''
     name = ''
-    email = 'unknown'
+    email = ''
     author = author.replace('"', '')
     match = AUTHOR.match(author)
     if match:
@@ -48,10 +49,10 @@ def sanitize_author(author):
         else:
             name = author
 
-    if name:
-        return "%s <%s>" % (name, email)
-    else:
-        return "<%s>" % (email)
+    if not name:
+        name = 'Unknown'
+
+    return "%s <%s>" % (name, email)
 
 
 class HGImporter(object):

--- a/test/test_author.py
+++ b/test/test_author.py
@@ -33,7 +33,7 @@ def test_author_no_email(git_dir, hg_repo):
     make_hg_commit("b", user="no email supplied")
 
     clone_repo(git_dir, hg_repo)
-    assert_git_author(author='no email supplied <unknown>')
+    assert_git_author(author='no email supplied <>')
 
 
 def test_author_only_email(git_dir, hg_repo):
@@ -41,7 +41,7 @@ def test_author_only_email(git_dir, hg_repo):
     make_hg_commit("b", user="<email@example.com>")
 
     clone_repo(git_dir, hg_repo)
-    assert_git_author(author='<email@example.com>')
+    assert_git_author(author='Unknown <email@example.com>')
 
 
 def test_author_only_email_no_quote(git_dir, hg_repo):
@@ -49,7 +49,7 @@ def test_author_only_email_no_quote(git_dir, hg_repo):
     make_hg_commit("b", user="email@example.com")
 
     clone_repo(git_dir, hg_repo)
-    assert_git_author(author='<email@example.com>')
+    assert_git_author(author='Unknown <email@example.com>')
 
 
 def test_author_no_space_before_email(git_dir, hg_repo):


### PR DESCRIPTION
1) Git requires a name. Although git 1.8 seems to be more lenient about this, 1.7.10 breaks.
2) Git allows an empty email address as long as <> is present. This makes more sense than <unknown>.
