### PR TITLE
Tagging does not use regular user name

### DIFF
--- a/gitifyhg/gitexporter.py
+++ b/gitifyhg/gitexporter.py
@@ -27,7 +27,7 @@ from mercurial.bookmarks import pushbookmark
 from mercurial.scmutil import revsingle
 
 from .util import (log, die, output, git_to_hg_spaces, hgmode, branch_tip,
-    ref_to_name_reftype, BRANCH, BOOKMARK, TAG)
+    ref_to_name_reftype, BRANCH, BOOKMARK, TAG, user_config)
 
 
 class GitExporter(object):
@@ -48,6 +48,7 @@ class GitExporter(object):
         self.parser = parser
         self.processed_marks = set()
         self.processed_nodes = []
+        self.hgrc = user_config()
 
     def process(self):
         self.marks.store()  # checkpoint
@@ -276,8 +277,8 @@ class GitExporter(object):
             date_tz = (date, tz)
         else:
             message = "Added tag %s for changeset %s" % (name, hgshort(node))
-            user = None
-            date_tz = None
+            user = self.hgrc.get("ui", "username", None)
+            date_tz = None # XXX insert current date here
         ctx = memctx(self.repo,
             (branch_tip(self.repo, branch), self.NULL_PARENT), message,
             ['.hgtags'], get_filectx, user, date_tz, {'branch': branch})

--- a/gitifyhg/util.py
+++ b/gitifyhg/util.py
@@ -4,6 +4,8 @@ import json
 
 from mercurial.node import hex as hghex  # What idiot overroad a builtin?
 from mercurial.node import bin as hgbin
+from mercurial.config import config
+from mercurial.scmutil import userrcpath
 
 
 DEBUG_GITIFYHG = os.environ.get("DEBUG_GITIFYHG") != None
@@ -138,6 +140,20 @@ def name_reftype_to_ref(name, reftype):
         return 'refs/tags/%s' % name
     assert False, "unknown reftype: %s" % reftype
 
+def user_config():
+    """Read the Mercurial user configuration
+
+    This is typically ~/.hgrc on POSIX.  This is returned
+    as a Mercurial.config.config object.
+    """
+    hgrc = config()
+    for cfg in userrcpath():
+        if not os.path.exists(cfg):
+            log("NOT reading missing cfg: " + cfg)
+            continue
+        log("Reading config: " + cfg)
+        hgrc.read(cfg)
+    return hgrc
 
 class HGMarks(object):
     '''Maps integer marks to specific string mercurial revision identifiers.


### PR DESCRIPTION
When I tag and push, my usual user-name (which is specified in my `~/.gitconfig`) is not used.

```
price@hsca-01:~/hsc/hscDb[master] $ git tag 2.1.0
price@hsca-01:~/hsc/hscDb[master] $ git push origin 2.1.0
no username found, using 'price@hsca-01.ipmu.nospam' instead
To gitifyhg::ssh://mitaka//ana/hgrepo/hscDb
 * [new tag]         2.1.0 -> 2.1.0
```

And then the history shows:

```
* commit 0f371cf07d1d243a925846cec1e338f017b8c6ce (HEAD, origin/master, origin/H
| Author:  <price@hsca-01.ipmu.nospam>
| Date:   Fri Mar 15 03:10:35 2013 +0900
| 
|     Added tag 2.1.0 for changeset aa38d9ad2aba
| 
|  .hgtags |    1 +
|  1 file changed, 1 insertion(+)
```

i.e., the `Author` is not my usual username.
