### PR TITLE
Clone fails

### DIFF
--- a/gitifyhg/gitifyhg.py
+++ b/gitifyhg/gitifyhg.py
@@ -41,7 +41,7 @@ from mercurial.util import version as hg_version
 from mercurial import hg
 from mercurial.bookmarks import listbookmarks, readcurrent
 
-from .util import (log, die, output, actual_stdout, branch_head, GitMarks,
+from .util import (log, die, output, branch_head, GitMarks,
     HGMarks, hg_to_git_spaces, name_reftype_to_ref, BRANCH, BOOKMARK, TAG,
     version, deactivate_stdout)
 from .hgimporter import HGImporter
@@ -193,7 +193,6 @@ class HGRemote(object):
             if command not in ('capabilities', 'list', 'import', 'export'):
                 die('unhandled command: %s' % line)
             getattr(self, 'do_%s' % command)(parser)
-            actual_stdout.flush()
 
         self.marks.store()
 

--- a/gitifyhg/hgimporter.py
+++ b/gitifyhg/hgimporter.py
@@ -23,7 +23,7 @@ import re
 
 from mercurial import encoding
 
-from .util import (log, output, actual_stdout, gittz, gitmode,
+from .util import (log, output, gittz, gitmode,
     git_to_hg_spaces, hg_to_git_spaces, branch_head, ref_to_name_reftype,
     BRANCH, BOOKMARK, TAG)
 
@@ -73,7 +73,6 @@ class HGImporter(object):
             output("feature import-marks=%s" % self.hgremote.marks_git_path)
         output("feature export-marks=%s" % self.hgremote.marks_git_path)
         output("feature notes")
-        actual_stdout.flush()
 
         tmp = encoding.encoding
         encoding.encoding = 'utf-8'

--- a/gitifyhg/util.py
+++ b/gitifyhg/util.py
@@ -13,7 +13,7 @@ BRANCH = 'branch'
 BOOKMARK = 'bookmark'
 TAG = 'tag'
 
-actual_stdout = sys.stdout
+actual_stdout = os.fdopen(sys.stdout.fileno(), 'w', 0) # Ensure stdout is unbuffered
 def deactivate_stdout():
     """Hijack stdout to prevent mercurial from inadvertently talking to git.
 


### PR DESCRIPTION
Here's a cut/paste of the command and resulting output.  I'm happy to provide more information as requested.

git-remote-hg (commit 864b5c41e472f2411d11620d3841b2b0dfceb9ec) works.

```
pprice@tiger3:~/test $ git clone gitifyhg::ssh://mitaka//ana/hgrepo/hscPipe
Cloning into 'hscPipe'...
error: refs/remotes/origin/branches/Winter2012d does not point to a valid object!
error: refs/remotes/origin/branches/forced-model-phot does not point to a valid object!
error: refs/remotes/origin/branches/hscPipe1.4.4 does not point to a valid object!
error: refs/remotes/origin/branches/hsc_onsite does not point to a valid object!
error: refs/remotes/origin/branches/hsc_onsite2 does not point to a valid object!
error: refs/remotes/origin/branches/hsc_onsite3 does not point to a valid object!
error: refs/remotes/origin/branches/price does not point to a valid object!
error: refs/remotes/origin/branches/stage-ncsa-2 does not point to a valid object!
error: refs/remotes/origin/branches/stage-ncsa-3 does not point to a valid object!
error: refs/remotes/origin/branches/stage-ncsa-4 does not point to a valid object!
error: refs/remotes/origin/branches/tickets/2140 does not point to a valid object!
error: refs/remotes/origin/master does not point to a valid object!
error: refs/tags/1.0.0 does not point to a valid object!
error: refs/tags/1.0.1 does not point to a valid object!
error: refs/tags/1.0.2 does not point to a valid object!
error: refs/tags/1.0.3 does not point to a valid object!
error: refs/tags/1.0.4 does not point to a valid object!
error: refs/tags/1.0.5 does not point to a valid object!
error: refs/tags/1.1.0 does not point to a valid object!
error: refs/tags/1.1.1 does not point to a valid object!
error: refs/tags/1.10.0 does not point to a valid object!
error: refs/tags/1.10.1 does not point to a valid object!
error: refs/tags/1.10.2 does not point to a valid object!
error: refs/tags/1.10.3 does not point to a valid object!
error: refs/tags/1.10.4 does not point to a valid object!
error: refs/tags/1.11.0 does not point to a valid object!
error: refs/tags/1.11.1 does not point to a valid object!
error: refs/tags/1.11.2 does not point to a valid object!
error: refs/tags/1.12.0 does not point to a valid object!
error: refs/tags/1.12.1 does not point to a valid object!
error: refs/tags/1.13.0 does not point to a valid object!
error: refs/tags/1.2.0 does not point to a valid object!
error: refs/tags/1.3.0 does not point to a valid object!
error: refs/tags/1.4.0 does not point to a valid object!
error: refs/tags/1.4.1 does not point to a valid object!
error: refs/tags/1.4.2 does not point to a valid object!
error: refs/tags/1.4.3 does not point to a valid object!
error: refs/tags/1.4.4 does not point to a valid object!
error: refs/tags/1.5.0 does not point to a valid object!
error: refs/tags/1.5.1 does not point to a valid object!
error: refs/tags/1.6.0 does not point to a valid object!
error: refs/tags/1.7.0 does not point to a valid object!
error: refs/tags/1.8.0 does not point to a valid object!
error: refs/tags/1.8.1 does not point to a valid object!
error: refs/tags/1.9.0 does not point to a valid object!
error: refs/tags/1.9.1 does not point to a valid object!
error: refs/tags/2.0.0 does not point to a valid object!
error: refs/tags/2.1.0 does not point to a valid object!
error: refs/tags/2.2.0 does not point to a valid object!
error: refs/tags/2.2.1 does not point to a valid object!
error: refs/tags/HSC-unstable does not point to a valid object!
error: refs/tags/HSC-unstable-3.0 does not point to a valid object!
error: refs/tags/HSC-unstable-3.1 does not point to a valid object!
error: refs/tags/HSC-unstable-3.2 does not point to a valid object!
error: refs/tags/HSC-unstable-3.3 does not point to a valid object!
error: refs/tags/HSC-unstable-4.0 does not point to a valid object!
error: refs/tags/HSC-unstable-4.1 does not point to a valid object!
error: Trying to write ref refs/heads/master with nonexistent object 0000000000000000000000000000000000000000
fatal: Cannot update the ref 'HEAD'.
Traceback (most recent call last):
  File "/home/pprice/local/Linux.x86_64/bin/git-remote-gitifyhg", line 9, in <module>
    load_entry_point('gitifyhg==0.8.1', 'console_scripts', 'git-remote-gitifyhg')()
  File "/home/pprice/local/Linux.x86_64/lib/python2.6/site-packages/gitifyhg-0.8.1-py2.6.egg/gitifyhg/gitifyhg.py", line 262, in main
    HGRemote(*[x.decode('utf-8') for x in sys.argv[1:3]]).process()
  File "/home/pprice/local/Linux.x86_64/lib/python2.6/site-packages/gitifyhg-0.8.1-py2.6.egg/gitifyhg/gitifyhg.py", line 175, in process
    self.marks.store()
  File "/home/pprice/local/Linux.x86_64/lib/python2.6/site-packages/gitifyhg-0.8.1-py2.6.egg/gitifyhg/util.py", line 116, in store
    with self.storage_path.open('w') as file:
  File "/home/pprice/local/Linux.x86_64/lib/python2.6/site-packages/path.py-3.0.1-py2.6.egg/path.py", line 589, in open
pprice@tiger3:~/test $     return open(self, mode)
IOError: [Errno 2] No such file or directory: path(u'/home/pprice/test/hscPipe/.git/hg/326df9a5b3e17503555a0e0c3388c7b67353e8ad/marks-hg')
```

```
pprice@tiger3:~/test $ git clone hg::ssh://mitaka//ana/hgrepo/hscPipe
Cloning into 'hscPipe'...
progress revision 99 'master' (100/516)
progress revision 199 'master' (200/516)
progress revision 299 'master' (300/516)
progress revision 399 'master' (400/516)
progress revision 499 'master' (500/516)
```
