### PR TITLE
 Allow HGRCPATH from environment to propagate to mercurial

### DIFF
--- a/gitifyhg/gitifyhg.py
+++ b/gitifyhg/gitifyhg.py
@@ -29,9 +29,6 @@ from path import path as p
 # Enable "plain" mode to make us resilient against changes to the locale, as we
 # rely on parsing certain messages produced by Mercurial. See issue #26.
 os.environ['HGPLAIN'] = '1'
-# Disable loading of the user's $HOME/.hgrc as extensions can cause weird
-# interactions and it's better to run in a known state.
-os.environ['HGRCPATH'] = ''
 
 
 from mercurial.ui import ui


### PR DESCRIPTION
If the user sets HGRCPATH, it is likely because they want to affect the
environment used to make commits (relevant when translating git
lightweight tags to mercurial tags) or because they would like to add an
extension such as keyring or schemes to the environment.

We are not aware of Mercurial extensions that would negatively affect
the behavior of the interfaces that Gitifyhg uses.

This reverts part of 468a4fe8c46f7fb6f571e1902b91b1ce66b831ea
