### PR TITLE
include LICENSE.txt and tests in source tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.txt
+recursive-include test Makefile *.sh *.t


### PR DESCRIPTION
I'd like to package gitifyhg for Fedora, but the source tarball on PyPI is missing a copy of the GPLv3. It's a requirement of the GPL itself that the license text be included with the source, and I need to ship it with the package as well:

https://fedoraproject.org/wiki/Packaging:LicensingGuidelines#License_Text

This patch adds a MANIFEST.in to bundle LICENSE.txt in the source tarball.

I also added the tests, because I'd like to run them during package build to make sure everything is working.
