### PR TITLE
README: quote asterisk to fix rST syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Should you actually encounter any compatibility issues with any older or
 newer Mercurial versions, please submit an issue.
 
 It has been tested on Arch Linux and Mac OS X. In general it should
-work equally well on other Unix-like operating systems like *BSD or Solaris.
+work equally well on other Unix-like operating systems like \*BSD or Solaris.
 All bets are off with Windows, but please let us know if it works or you fixed
 it.
 


### PR DESCRIPTION
Asterisks are special characters in rST, and we have to quote this one with a backslash.